### PR TITLE
Add all the missing section heading levels

### DIFF
--- a/src/Prismic/Field.elm
+++ b/src/Prismic/Field.elm
@@ -237,6 +237,15 @@ structuredTextBlockAsHtml linkResolver field =
         Heading3 block ->
             blockAsHtml Html.h3 linkResolver block
 
+        Heading4 block ->
+            blockAsHtml Html.h4 linkResolver block
+
+        Heading5 block ->
+            blockAsHtml Html.h5 linkResolver block
+
+        Heading6 block ->
+            blockAsHtml Html.h6 linkResolver block
+
         Paragraph block ->
             blockAsHtml Html.p linkResolver block
 
@@ -384,6 +393,15 @@ getTitle (StructuredText st) =
                 Heading3 _ ->
                     True
 
+                Heading4 _ ->
+                    True
+
+                Heading5 _ ->
+                    True
+
+                Heading6 _ ->
+                    True
+
                 _ ->
                     False
     in
@@ -434,6 +452,15 @@ getText field =
             block.text
 
         Heading3 block ->
+            block.text
+
+        Heading4 block ->
+            block.text
+
+        Heading5 block ->
+            block.text
+
+        Heading6 block ->
             block.text
 
         Paragraph block ->

--- a/src/Prismic/Internal.elm
+++ b/src/Prismic/Internal.elm
@@ -173,6 +173,9 @@ type StructuredTextBlock
     = Heading1 Block
     | Heading2 Block
     | Heading3 Block
+    | Heading4 Block
+    | Heading5 Block
+    | Heading6 Block
     | Paragraph Block
     | ListItem Block
     | SImage ImageView
@@ -663,6 +666,15 @@ decodeStructuredTextBlock =
 
                 "heading3" ->
                     Json.map Heading3 decodeBlock
+
+                "heading4" ->
+                    Json.map Heading4 decodeBlock
+
+                "heading5" ->
+                    Json.map Heading5 decodeBlock
+
+                "heading6" ->
+                    Json.map Heading6 decodeBlock
 
                 "paragraph" ->
                     Json.map Paragraph decodeBlock


### PR DESCRIPTION
This fixes an issue decoding current (as of 2020-08-08) campaign texts. The issue was detected as part of https://github.com/miaEngiadina/engiadina-pwa/pull/164.