### PR TITLE
Fix list collation

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,15 +12,16 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "NoRedInk/json-decode-pipeline": "2.0.0 <= v < 3.0.0",
-        "elm-lang/core": "1.0.0 <= v < 2.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "elm-lang/http": "2.0.0 <= v < 3.0.0",
-        "elm-lang/json": "1.0.0 <= v < 2.0.0",
-        "elm-lang/time": "1.0.0 <= v < 2.0.0",
-        "elm-lang/url": "1.0.0 <= v < 2.0.0",
-        "rtfeldman/elm-iso8601-date-strings": "1.0.0 <= v < 2.0.0",
-        "hecrj/html-parser": "2.0.0 <= v < 3.0.0"
+        "NoRedInk/elm-json-decode-pipeline": "1.0.0 <= v < 2.0.0",
+        "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm/html": "1.0.0 <= v < 2.0.0",
+        "elm/http": "2.0.0 <= v < 3.0.0",
+        "elm/json": "1.0.0 <= v < 2.0.0",
+        "elm/time": "1.0.0 <= v < 2.0.0",
+        "elm/url": "1.0.0 <= v < 2.0.0",
+        "elm-community/list-extra": "8.2.4 <= v < 9.0.0",
+        "hecrj/html-parser": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/elm-iso8601-date-strings": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {}
 }


### PR DESCRIPTION
The earlier algorithm to collate ListItems and OListItems sometimes ate all lists :disappointed: 

Using this simpler solution, the expected happens: `[ListItem [x], ListItem [y], Paragraph z, OListItem [v], OListItem [w]] -> [ListItem [x, y], Paragraph z, OListItem [v, w]]`